### PR TITLE
Bump rand version to 0.4.x.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reservoir"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Nat Pryce <sw@natpryce.com>"]
 description="Reservoir sampling of iterators"
 homepage = "https://github.com/npryce/reservoir-rs"
@@ -9,4 +9,4 @@ license="Apache-2.0"
 readme="README.md"
 
 [dependencies]
-rand = "0.3.11"
+rand = "0.4"


### PR DESCRIPTION
Thanks for reservoir! It is a small, but useful crate.

I would like to use rand 0.4 in some software where I also use the reservoir crate. Unfortunately, using 0.4 together with a crate based on 0.3 gives trait problems.

This small change bumps the rand dependency to 0.4, which is good for any 0.4.x.