### PR TITLE
Use rand 0.6.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ license="Apache-2.0"
 readme="README.md"
 
 [dependencies]
-rand = "0.3.11"
+rand = "0.6.1"


### PR DESCRIPTION
Like #3 but with a newer rand version.

This is a handy little library but since the user needs to provide the rng to use it's painful to be using such an old rand version. (If you're not interested in keeping this up to date, are you open to handing over maintainership to someone else?)